### PR TITLE
Make usage of Azure.SASToken idempotent

### DIFF
--- a/src/azure.jl
+++ b/src/azure.jl
@@ -176,8 +176,12 @@ function azuresign!(request::HTTP.Request; credentials=nothing, addMd5::Bool=tru
         return
     elseif creds isa SASToken
         url = request.url
-        query = url.query
-        request.url = URI(url; query=isempty(query) ? creds.token : string(query, "&", creds.token))
+        query = URIs.queryparampairs(url)
+        toks = URIs.queryparampairs(creds.token)
+        for pair in toks
+            HTTP.setbyfirst(query, pair)
+        end
+        request.url = URI(url; query)
         request.target = HTTP.resource(request.url)
         return
     end


### PR DESCRIPTION
The issue here was how we were including the SASToken for authorization in the request url. We were adding it to the url query, regardless of what was already present. The problem is in the case of retries, we ended up adding the SASToken multiple times to the query. This parses the url query and sas token and ensures the individual token pieces are only present once in the query before reserializing the request url/target.