### PR TITLE
Quick cleanup of new functionality

### DIFF
--- a/src/CloudBase.jl
+++ b/src/CloudBase.jl
@@ -81,8 +81,8 @@ function cloudmetricslayer(handler)
             timeout_errors = get(req.context, :timeout_errors, 0)
             connect_duration_ms = get(req.context, :connect_duration_ms, 0.0)
             dur = (time() - start) * 1000
-            if logexceptionalduration > 0 && dur > logexceptionalduration
-                @error "Exceptionally long cloud request:" total_duration_ms=dur method=req.method context=req.context
+            if logexceptionalduration > 0 && div(dur, 1000) > logexceptionalduration
+                @warn "Exceptionally long cloud request:" total_duration_ms=dur method=req.method context=req.context
             end
             METRICS_CALLBACK[](req.method, failed, retries, dur, bytes_sent, bytes_received,
                 connect_errors, io_errors, status_errors, timeout_errors,


### PR DESCRIPTION
Make `logexceptionalduration` take # of _seconds_, not milliseconds to be more consistent with other HTTP duration-related keyword args.

Also change the log to a `@warn` instead of error.