### PR TITLE
Add bindIP option to minio

### DIFF
--- a/src/CloudTest.jl
+++ b/src/CloudTest.jl
@@ -165,7 +165,7 @@ publicPolicy(bucket) = """
 # use `with`, not `run`! if you `run`, it returns `conf, p`, where `p` is the server process
 # note that existing the Julia process *will not* stop the server process, which can easily
 # lead to "dangling" server processes. You can `kill(p)` to stop the server process manually
-function run(; dir=nothing, bucket=nothing, public=false, startupDelay=0.25, debug=false, bindIP="")
+function run(; dir=nothing, bucket=nothing, public=false, startupDelay=0.25, debug=false, bindIP="127.0.0.1")
     if dir === nothing
         dir = mktempdir()
     elseif !isdir(dir)

--- a/src/CloudTest.jl
+++ b/src/CloudTest.jl
@@ -165,7 +165,7 @@ publicPolicy(bucket) = """
 # use `with`, not `run`! if you `run`, it returns `conf, p`, where `p` is the server process
 # note that existing the Julia process *will not* stop the server process, which can easily
 # lead to "dangling" server processes. You can `kill(p)` to stop the server process manually
-function run(; dir=nothing, bucket=nothing, public=false, startupDelay=0.25, debug=false)
+function run(; dir=nothing, bucket=nothing, public=false, startupDelay=0.25, debug=false, bindIP="")
     if dir === nothing
         dir = mktempdir()
     elseif !isdir(dir)
@@ -173,7 +173,7 @@ function run(; dir=nothing, bucket=nothing, public=false, startupDelay=0.25, deb
     end
     p, port = findOpenPorts(2) do ports
         port, cport = ports
-        cmd = _cmd(`$(minio_jll.minio()) server $dir --address :$(port) --console-address :$(cport)`)
+        cmd = _cmd(`$(minio_jll.minio()) server $dir --address $(bindIP):$(port) --console-address $(bindIP):$(cport)`)
         p = debug ? Base.run(cmd, devnull, stderr, stderr; wait=false) : Base.run(cmd; wait=false)
         sleep(startupDelay) # sleep just a little for server startup
         return p, port

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -37,7 +37,7 @@ end
 
 @time @testset "AWS" begin
     config = Ref{Any}()
-    Minio.with(startupDelay=3) do conf
+    Minio.with(bindIP="127.0.0.1", startupDelay=3) do conf
         config[] = conf
         credentials, bucket = conf
         csv = "a,b,c\n1,2,3\n4,5,$(rand())"
@@ -48,7 +48,7 @@ end
     @test !isdir(config[].dir)
     @test success(config[].process)
     # test public access
-    Minio.with(startupDelay=3, public=true) do conf
+    Minio.with(bindIP="127.0.0.1", startupDelay=3, public=true) do conf
         credentials, bucket = conf
         csv = "a,b,c\n1,2,3\n4,5,$(rand())"
         AWS.put("$(bucket.baseurl)test.csv", [], csv; service="s3")
@@ -116,7 +116,7 @@ end
     mconfigs = Vector{Any}(undef, 10)
     aconfigs = Vector{Any}(undef, 10)
     @sync for i = 1:10
-        @async Minio.with(startupDelay=3) do conf
+        @async Minio.with(bindIP="127.0.0.1", startupDelay=3) do conf
             mconfigs[i] = conf
             credentials, bucket = conf
             csv = "a,b,c\n1,2,3\n4,5,$(rand())"
@@ -211,7 +211,7 @@ end
 
 # metrics hooks
 @time @testset "Cloud metrics hooks" begin
-    Minio.with(startupDelay=3) do conf
+    Minio.with(bindIP="127.0.0.1", startupDelay=3) do conf
         credentials, bucket = conf
         prereq_ref = Ref(0)
         metrics_ref = Ref{Any}()


### PR DESCRIPTION
On MacOS, every instance of a minio server was creating a very annoying firewall popup. I discovered that this is because it was trying to bind to all IPs. This PR adds an option to specify the bind IP address, which lets us bind to loopback only and does not cause a popup.