### PR TITLE
Fix Azurite/Minio container naming

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CloudBase"
 uuid = "85eb1798-d7c4-4918-bb13-c944d38e27ed"
 authors = ["quinnj <quinn.jacobd@gmail.com>"]
-version = "1.4.4"
+version = "1.4.5"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/src/CloudTest.jl
+++ b/src/CloudTest.jl
@@ -179,7 +179,7 @@ function run(; dir=nothing, bucket=nothing, public=false, startupDelay=0.25, deb
         return p, port
     end
     credentials = AWS.Credentials("minioadmin", "minioadmin")
-    bkt = AWS.Bucket(something(bucket, "jl-minio-$(abs(rand(Int16)))"); host="http://127.0.0.1:$port")
+    bkt = AWS.Bucket(something(bucket, "jl-minio-$(rand(UInt16))"); host="http://127.0.0.1:$port")
     resp = AWS.put(bkt.baseurl, []; service="s3", credentials, status_exception=false)
     while resp.status != 200
         if resp.status == 503
@@ -296,7 +296,7 @@ function run(; dir=nothing, container=nothing, public=false, startupDelay=3, deb
     end
     acct = "devstoreaccount1"
     protocol = use_ssl ? "https" : "http"
-    cont = Azure.Container(something(container, "jl-azurite-$(abs(rand(Int16)))"), acct; host="$protocol://127.0.0.1:$port")
+    cont = Azure.Container(something(container, "jl-azurite-$(rand(UInt16))"), acct; host="$protocol://127.0.0.1:$port")
     key = "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw=="
     credentials = Azure.Credentials(acct, key)
     headers = public ? ["x-ms-blob-public-access" => "container"] : []


### PR DESCRIPTION
Azurite does not support double dashes in container names (a 400 bad request will be returned). This fixes a bug where a container name with double dashes could be generated if the random value is -32768, which overflows `abs` to still return -32768.