### PR TITLE
Add a basic support for parsing hosts from virtual private cloud

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CloudBase"
 uuid = "85eb1798-d7c4-4918-bb13-c944d38e27ed"
 authors = ["quinnj <quinn.jacobd@gmail.com>"]
-version = "1.4.5"
+version = "1.4.6"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -226,3 +226,11 @@ end
         @test prereq_ref[] == 2
     end
 end
+
+@testset "urlServiceRegion" begin
+    @test CloudBase.urlServiceRegion("amazonaws.com") == (nothing, nothing)
+    @test CloudBase.urlServiceRegion("s3.amazonaws.com") == ("s3", nothing)
+    @test CloudBase.urlServiceRegion("s3.us-west-2.amazonaws.com") == ("s3", "us-west-2")
+    @test CloudBase.urlServiceRegion("bucket.s3.us-west-2.amazonaws.com") == ("s3", "us-west-2")
+    @test CloudBase.urlServiceRegion("bucket.vpce-1a2b3c4d-5e6f.s3.us-east-1.vpce.amazonaws.com") == ("s3", "us-east-1")
+end


### PR DESCRIPTION
A very simple fix,we would ideally use something more robust to parse the input. Maybe we could see what the [Java SDK](https://github.com/aws/aws-sdk-java-v2/blob/b85450fc77a6939abf734dcf01ddb90a8f277669/services/s3/src/main/java/software/amazon/awssdk/services/s3/S3Utilities.java#L292) does.