### PR TITLE
Redact AWS credentials printing like Azure

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CloudBase"
 uuid = "85eb1798-d7c4-4918-bb13-c944d38e27ed"
 authors = ["quinnj <quinn.jacobd@gmail.com>"]
-version = "1.4.6"
+version = "1.4.7"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/src/aws.jl
+++ b/src/aws.jl
@@ -12,11 +12,13 @@ end
 
 
 function Base.show(io::IO, creds::AWSCredentials)
-    print(io, "AWSCredentials(\
-        profile=$(creds.profile), access_key_id=****, \
-        secret_access_key=****, session_token=****, \
-        expiration=$(creds.expiration), expireThreshold=$(creds.expireThreshold))"
-    )
+    print(io, "AWSCredentials(")
+    print(io, "profile=", creds.profile, ",")
+    print(io, "access_key_id=", "****", ",")
+    print(io, "secret_access_key=", "****", ",")
+    print(io, "session_token=", "****", ",")
+    print(io, "expiration=", creds.expiration, ",")
+    print(io, "expireThreshold=", creds.expireThreshold, ")")
 end
 
 AWSCredentials(profile::String, access_key_id::String, secret_access_key::String, session_token::String, expiration, expireThreshold) =

--- a/src/aws.jl
+++ b/src/aws.jl
@@ -10,6 +10,15 @@ mutable struct AWSCredentials <: CloudCredentials
     expireThreshold::Dates.Period
 end
 
+
+function Base.show(io::IO, creds::AWSCredentials)
+    print(io, "AWSCredentials(\
+        profile=$(creds.profile), access_key_id=****, \
+        secret_access_key=****, session_token=****, \
+        expiration=$(creds.expiration), expireThreshold=$(creds.expireThreshold))"
+    )
+end
+
 AWSCredentials(profile::String, access_key_id::String, secret_access_key::String, session_token::String, expiration, expireThreshold) =
     AWSCredentials(ReentrantLock(), profile, access_key_id, secret_access_key, session_token, expiration, expireThreshold)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -234,3 +234,19 @@ end
     @test CloudBase.urlServiceRegion("bucket.s3.us-west-2.amazonaws.com") == ("s3", "us-west-2")
     @test CloudBase.urlServiceRegion("bucket.vpce-1a2b3c4d-5e6f.s3.us-east-1.vpce.amazonaws.com") == ("s3", "us-east-1")
 end
+
+@testset "redact credentials" begin
+    # Make sure we don't show secrets in the output
+    function test_output(creds)
+        io_buffer = IOBuffer()
+        Base.show(io_buffer, creds)
+        str = String(take!(io_buffer))
+        @test !occursin("secret_pass", str)
+        @test occursin("***", str)
+        return nothing
+    end
+    test_output(CloudBase.AWSCredentials("secret_pass", "secret_pass", "secret_pass"))
+    # same for Azure
+    test_output(Azure.Credentials(CloudBase.SharedKey("account_name", "secret_pass")))
+    test_output(Azure.Credentials(CloudBase.generateAccountSASToken("account_name", "secret_pass")))
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -241,12 +241,12 @@ end
         io_buffer = IOBuffer()
         Base.show(io_buffer, creds)
         str = String(take!(io_buffer))
-        @test !occursin("secret_pass", str)
+        @test !occursin("0123456789abcdef", str)
         @test occursin("***", str)
         return nothing
     end
-    test_output(CloudBase.AWSCredentials("secret_pass", "secret_pass", "secret_pass"))
+    test_output(CloudBase.AWSCredentials("0123456789abcdef", "0123456789abcdef", "0123456789abcdef"))
     # same for Azure
-    test_output(Azure.Credentials(CloudBase.SharedKey("account_name", "secret_pass")))
-    test_output(Azure.Credentials(CloudBase.generateAccountSASToken("account_name", "secret_pass")))
+    test_output(Azure.Credentials(CloudBase.SharedKey("account_name", "0123456789abcdef")))
+    test_output(Azure.Credentials(CloudBase.generateAccountSASToken("account_name", "0123456789abcdef")))
 end


### PR DESCRIPTION
Currently, we only remove secrets while printing Azure credentials (cf. `Base.show(io::IO, x::SharedKey)`). 
This PR does the same for AWS credentials as a proactive measure.