### PR TITLE
[CloudTest] Wait for server port to be open instead of a fixed delay

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CloudBase"
 uuid = "85eb1798-d7c4-4918-bb13-c944d38e27ed"
 authors = ["quinnj <quinn.jacobd@gmail.com>"]
-version = "1.4.7"
+version = "1.4.8"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/src/CloudTest.jl
+++ b/src/CloudTest.jl
@@ -81,7 +81,8 @@ end
 
 function _connect_with_timeout(host, port::Integer, timeout::Number)
     s = TCPSocket()
-    t = Timer(_ -> close(s), timeout)
+    # we wrap it in this way so that the current task does not become sticky
+    t = fetch(Threads.@spawn(Timer(_ -> close(s), timeout)))::Timer
     try
         connect(s, host, port)
     catch e
@@ -93,7 +94,6 @@ function _connect_with_timeout(host, port::Integer, timeout::Number)
     finally
         close(t)
     end
-    @show
     return s
 end
 


### PR DESCRIPTION
Currently in CloudTest we have a configurable but fixed delay when waiting for the Minio/Azurite server to be up. This can lead to excessive waiting when running many tests and tuning the wait time depends on the runtime environment. We propose an explicit wait for the port to be open instead of the fixed delay.