### PR TITLE
[CloudTest] Make TCP port wait period configurable

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CloudBase"
 uuid = "85eb1798-d7c4-4918-bb13-c944d38e27ed"
 authors = ["quinnj <quinn.jacobd@gmail.com>"]
-version = "1.4.8"
+version = "1.4.9"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/Project.toml
+++ b/Project.toml
@@ -31,7 +31,7 @@ SHA = "0, 1, 2"
 URIs = "1"
 azurite_jll = "3"
 julia = "1.6"
-minio_jll = "1"
+minio_jll = "2"
 
 [extras]
 JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"

--- a/src/CloudTest.jl
+++ b/src/CloudTest.jl
@@ -152,6 +152,7 @@ keyword arguments include:
     can be useful on slower systems to allow time for the server
     to fully startup
   * `debug`: whether to turn on minio debug logging, defaults to `false`
+  * `waitForPortTimeout`: Time to wait in seconds for the TCP port of Minio to be ready for connections
 """
 function with(f; dir=nothing, kw...)
     config, proc = run(; dir, kw...)
@@ -259,6 +260,7 @@ keyword arguments include:
     can be useful on slower systems to allow time for the server
     to fully startup
   * `debug`: whether to turn on minio debug logging, defaults to `false`
+  * `waitForPortTimeout`: Time to wait in seconds for the TCP port of Azurite to be ready for connections
 """
 function with(f; dir=nothing, debug::Bool=false, debugLog::Union{Nothing, Ref{String}}=nothing, kw...)
     config, proc = run(; dir, debug, kw...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -38,7 +38,7 @@ end
 
 @time @testset "AWS" begin
     config = Ref{Any}()
-    Minio.with(bindIP="127.0.0.1", startupDelay=3) do conf
+    Minio.with(bindIP="127.0.0.1", startupDelay=3, waitForPortTimeout=10) do conf
         config[] = conf
         credentials, bucket = conf
         csv = "a,b,c\n1,2,3\n4,5,$(rand())"
@@ -67,7 +67,7 @@ end
 if !x32bit
 @time @testset "Azure" begin
     config = Ref{Any}()
-    Azurite.with(startupDelay=3) do conf
+    Azurite.with(startupDelay=3, waitForPortTimeout=10) do conf
         config[] = conf
         credentials, container = conf
         csv = "a,b,c\n1,2,3\n4,5,$(rand())"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -38,7 +38,7 @@ end
 
 @time @testset "AWS" begin
     config = Ref{Any}()
-    Minio.with(bindIP="127.0.0.1", startupDelay=3, waitForPortTimeout=10) do conf
+    Minio.with(bindIP="127.0.0.1", startupDelay=0.5, waitForPortTimeout=10) do conf
         config[] = conf
         credentials, bucket = conf
         csv = "a,b,c\n1,2,3\n4,5,$(rand())"
@@ -49,7 +49,7 @@ end
     @test !isdir(config[].dir)
     @test success(config[].process)
     # test public access
-    Minio.with(bindIP="127.0.0.1", startupDelay=3, public=true) do conf
+    Minio.with(bindIP="127.0.0.1", startupDelay=0.5, public=true) do conf
         credentials, bucket = conf
         csv = "a,b,c\n1,2,3\n4,5,$(rand())"
         AWS.put("$(bucket.baseurl)test.csv", [], csv; service="s3")
@@ -67,7 +67,7 @@ end
 if !x32bit
 @time @testset "Azure" begin
     config = Ref{Any}()
-    Azurite.with(startupDelay=3, waitForPortTimeout=10) do conf
+    Azurite.with(startupDelay=0.5, waitForPortTimeout=10) do conf
         config[] = conf
         credentials, container = conf
         csv = "a,b,c\n1,2,3\n4,5,$(rand())"
@@ -97,7 +97,7 @@ if !x32bit
     @test !isdir(config[].dir)
     @test success(config[].process)
     # test public access
-    Azurite.with(startupDelay=3, public=true) do conf
+    Azurite.with(startupDelay=0.5, public=true) do conf
         credentials, container = conf
         csv = "a,b,c\n1,2,3\n4,5,$(rand())"
         # have to supply credentials for put since "public" is only for get
@@ -117,7 +117,7 @@ end
     mconfigs = Vector{Any}(undef, 10)
     aconfigs = Vector{Any}(undef, 10)
     @sync for i = 1:10
-        @async Minio.with(bindIP="127.0.0.1", startupDelay=3) do conf
+        @async Minio.with(bindIP="127.0.0.1", startupDelay=0.5) do conf
             mconfigs[i] = conf
             credentials, bucket = conf
             csv = "a,b,c\n1,2,3\n4,5,$(rand())"
@@ -126,7 +126,7 @@ end
             @test String(resp.body) == csv
         end
         if !x32bit
-            @async Azurite.with(startupDelay=3) do conf
+            @async Azurite.with(startupDelay=0.5) do conf
                 aconfigs[i] = conf
                 credentials, container = conf
                 csv = "a,b,c\n1,2,3\n4,5,$(rand())"
@@ -212,7 +212,7 @@ end
 
 # metrics hooks
 @time @testset "Cloud metrics hooks" begin
-    Minio.with(bindIP="127.0.0.1", startupDelay=3) do conf
+    Minio.with(bindIP="127.0.0.1", startupDelay=0.5) do conf
         credentials, bucket = conf
         prereq_ref = Ref(0)
         metrics_ref = Ref{Any}()


### PR DESCRIPTION
Makes it possible to configure the time we wait for the Minio/Azurite TCP port to be open, increases the default period and makes use of `startupDelay` for Azurite.