### PR TITLE
Fix SigV4 signing for escaped S3 object paths

### DIFF
--- a/src/aws.jl
+++ b/src/aws.jl
@@ -335,7 +335,15 @@ function awssign!(request::HTTP.Request; service=nothing, region=nothing, creden
     # https://docs.aws.amazon.com/general/latest/gr/sigv4_signing.html
     # Task 1: Create a canonical request for Signature Version 4
     service = lowercase(service)
-    canonicalURI = URIs.normpath((service == "s3" || service == "service") ? uriencode(request.url.path, true) : escapepath(request.url.path))
+    request_path = isempty(request.url.path) ? "/" : request.url.path
+    canonicalURI = if service == "s3"
+        # Request URLs contain an escaped path. Decode it before applying SigV4
+        # encoding so `%20` is signed as `%20`, not `%2520`. Do not normalize
+        # S3 paths because repeated slashes and dot segments are object-key data.
+        uriencode(URIs.unescapeuri(request_path), true)
+    else
+        URIs.normpath(service == "service" ? uriencode(request_path, true) : escapepath(request_path))
+    end
     # @show canonicalURI
     canonicalQueryString = join((string(uriencode(k), "=", uriencode(v)) for (k, v) in sort!(queryparampairs(request.url); by=x->"$(x[1])$(x[2])")), "&")
     # @show request.url, queryparampairs(request.url), canonicalQueryString

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -61,7 +61,7 @@ end
     delete!(configs, :accessKeyId)
     delete!(configs, :secretAccessKey)
     debug = false
-    knownFailures = (19, 20, 23, 26)
+    knownFailures = (19, 20, 26)
     for (i, case) in enumerate(cases.tests.all)
         println("testing AWSSig4 case = $(case.name), i = $i")
         req = HTTP.Request(case.request.method, case.request.path, case.request.headers, case.request.body; url=HTTP.URI(case.request.uri))
@@ -94,6 +94,13 @@ end
         AWS.put("$(bucket.baseurl)test.csv", [], csv; service="s3", credentials)
         resp = AWS.get("$(bucket.baseurl)test.csv"; service="s3", credentials)
         @test String(resp.body) == csv
+
+        for key in ("with space", "with%20space", "plus+plus", "hash#hash", "unicode-ü")
+            escaped = join(HTTP.escapeuri.(split(key, '/'; keepempty=true)), '/')
+            url = string(bucket.baseurl, escaped)
+            AWS.put(url, [], key; service="s3", credentials)
+            @test String(AWS.get(url; service="s3", credentials).body) == key
+        end
     end
     @test !isdir(config[].dir)
     @test success(config[].process)


### PR DESCRIPTION
## Summary

- decode the escaped request path before applying AWS SigV4 path encoding
- preserve S3 repeated slashes and dot segments instead of normalizing object-key data
- add MinIO coverage for spaces, literal percent sequences, plus signs, hash signs, and Unicode
- enable AWS SigV4 conformance case 23, which now passes

This fixes the signing half of JuliaServices/CloudBase.jl#44. A companion CloudStore change encodes raw object keys before URL construction.

## Validation

- full CloudBase test suite passes
- AWS SigV4 conformance: 25 passed, 3 known broken
- combined CloudStore + CloudBase MinIO round trips pass for plain, nested, space, literal `%20`, `+`, `#`, and Unicode keys

Refs #44

Co-authored by Codex