### PR TITLE
Use ECS and EC2 metadata credentials directly

### DIFF
--- a/src/aws.jl
+++ b/src/aws.jl
@@ -142,12 +142,13 @@ function Figgy.load(x::ECSCredentialsSource)
     url = get(AWS_CONFIGS, "container_credentials_relative_uri", "")
     isempty(url) && return ()
     try
+        # RoleArn identifies the role for these already-vended credentials. It is not
+        # a request to assume the role again through STS.
         return Figgy.kmap(Figgy.JsonObject(HTTP.get("$host$url").body),
             "AccessKeyId" => "aws_access_key_id",
             "SecretAccessKey" => "aws_secret_access_key",
             "Token" => "aws_session_token",
             "Expiration" => "expiration",
-            "RoleArn" => "role_arn",
         )
     catch
         return ()
@@ -173,12 +174,13 @@ function Figgy.load(x::EC2CredentialsSource)
         role = String(HTTP.get("http://$host:$port/latest/meta-data/iam/security-credentials/").body)
         region = String(HTTP.get("http://$host:$port/latest/meta-data/placement/region").body)
         Figgy.load!(AWS_CONFIGS, "region" => region)
+        # The metadata service has already assumed the instance role and returned its
+        # temporary credentials. Do not treat response metadata as role configuration.
         return Figgy.kmap(Figgy.JsonObject(HTTP.get("http://$host:$port/latest/meta-data/iam/security-credentials/$role").body),
             "AccessKeyId" => "aws_access_key_id",
             "SecretAccessKey" => "aws_secret_access_key",
             "Token" => "aws_session_token",
             "Expiration" => "expiration",
-            "RoleArn" => "role_arn",
         )
     catch
         return ()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -204,16 +204,20 @@ end
 
 @testset "AWS ECS Task" begin
     ECS.with() do
+        delete!(CloudBase.AWS_CONFIGS, "role_arn")
         CloudBase.reloadECSCredentials!("http://127.0.0.1")
         @test get(CloudBase.AWS_CONFIGS, "aws_session_token", "") == "ECS_TOKEN"
+        @test !haskey(CloudBase.AWS_CONFIGS, "role_arn")
     end
 end
 
 @testset "AWS EC2" begin
     EC2.with() do
+        delete!(CloudBase.AWS_CONFIGS, "role_arn")
         CloudBase.reloadEC2Credentials!("127.0.0.1", 50397)
         @test get(CloudBase.AWS_CONFIGS, "aws_session_token", "") == "EC2_TOKEN"
         @test get(CloudBase.AWS_CONFIGS, "region", "") == "us-west-1"
+        @test !haskey(CloudBase.AWS_CONFIGS, "role_arn")
     end
 end
 


### PR DESCRIPTION
## Summary

- keep ECS task credentials as the active credentials returned by the metadata service
- keep EC2 instance-profile credentials on the same direct path
- stop mapping response metadata `RoleArn` to the configured `role_arn` setting
- prevent an invalid second STS `AssumeRole` request

Fixes JuliaServices/CloudStore.jl#56.

## Root cause

The metadata endpoints return temporary credentials that AWS has already vended for the task or instance role. CloudBase mapped the response `RoleArn` field to its `role_arn` configuration key. That key then triggered a second STS `AssumeRole` call with the just-loaded credentials. The reported failure came from that extra call, not from the metadata request.

## Validation

- full CloudBase test suite passed
- ECS metadata test confirms the session token loads and `role_arn` remains unset
- EC2 metadata test confirms the same behavior and preserves region loading

Co-authored by Codex
